### PR TITLE
Working drush command

### DIFF
--- a/web/modules/custom/ai_dashboard/ai_dashboard.routing.yml
+++ b/web/modules/custom/ai_dashboard/ai_dashboard.routing.yml
@@ -96,9 +96,15 @@ ai_dashboard.admin.import:
     _permission: 'administer ai dashboard imports'
 
 ai_dashboard.admin.import.run:
-  path: '/ai-dashboard/admin/import/run/{config_id}'
+  path: '/ai-dashboard/admin/import/run/{node}'
   defaults:
     _controller: '\Drupal\ai_dashboard\Controller\ImportAdminController::runImport'
+  options:
+    parameters:
+      node:
+        type: entity:node
+        bundle:
+          - ai_import_config
   requirements:
     _permission: 'administer ai dashboard imports'
     config_id: \d+

--- a/web/modules/custom/ai_dashboard/src/Controller/ImportAdminController.php
+++ b/web/modules/custom/ai_dashboard/src/Controller/ImportAdminController.php
@@ -5,6 +5,7 @@ namespace Drupal\ai_dashboard\Controller;
 use Drupal\Core\Controller\ControllerBase;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\ai_dashboard\Service\IssueImportService;
+use Drupal\node\NodeInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -182,16 +183,9 @@ class ImportAdminController extends ControllerBase {
   /**
    * Run import from specific configuration.
    */
-  public function runImport(Request $request, $config_id) {
-    $config = $this->entityTypeManager->getStorage('node')->load($config_id);
-
-    if (!$config || $config->bundle() !== 'ai_import_config') {
-      $this->messenger->addError('Import configuration not found.');
-      return new RedirectResponse(Url::fromRoute('ai_dashboard.admin.import')->toString());
-    }
-
+  public function runImport(NodeInterface $node) {
     try {
-      $results = $this->importService->importFromConfig($config, TRUE);
+      $results = $this->importService->importFromConfig($node, TRUE);
 
       // Check if this is a batch import that requires redirection.
       if ($results['success'] && isset($results['redirect']) && $results['redirect']) {

--- a/web/modules/custom/ai_dashboard/src/Service/IssueBatchImportService.php
+++ b/web/modules/custom/ai_dashboard/src/Service/IssueBatchImportService.php
@@ -317,7 +317,7 @@ class IssueBatchImportService {
       $results = $import_service->importFromDrupalOrg(
         $project_id,
         $filter_tags,
-      // Single status array.
+        // Single status array.
         $status_filter,
         $max_issues,
         $date_filter,
@@ -458,7 +458,6 @@ class IssueBatchImportService {
           $source_type,
           $project_id,
           $filter_tags,
-      // Single status array.
           [$single_status],
           $date_filter,
           $status_name,
@@ -489,7 +488,7 @@ class IssueBatchImportService {
     // For CLI, process immediately.
     $batch =& batch_get();
     $batch['progressive'] = FALSE;
-    batch_process();
+    drush_backend_batch_process();
 
     return [
       'success' => TRUE,


### PR DESCRIPTION
Fixed drush command, now possible to run
```
drush ai_dashboard:import <nid>
```
Also, moved the checks for import configuration bundle to routing.yml (no need to do it with PHP)
