### PR TITLE
feat(digest): stop mis-attributing work to named contributors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -204,5 +204,8 @@ test-kanban-login.js
 # Ignore local development code scratchpad
 .code/
 
+# Superpowers brainstorming/planning docs are local-only, never committed
+docs/superpowers/
+
 .devpanel/salt.txt
 config/sync/mailchimp.settings.yml

--- a/web/modules/custom/issue_analysis/src/Service/DailyDigestService.php
+++ b/web/modules/custom/issue_analysis/src/Service/DailyDigestService.php
@@ -489,6 +489,263 @@ class DailyDigestService {
   // ---------------------------------------------------------------------------
 
   /**
+   * Builds the deduplicated set of people who were active in the period.
+   *
+   * "Active" means the person actually did something inside [$since, $until]:
+   * authored a comment, authored an MR created/updated/merged in-window,
+   * authored a commit in-window, or had an MR of theirs merged in-window. A
+   * stale assignee who took no action in the window is deliberately excluded —
+   * we credit participation, not assignment.
+   *
+   * Used to render a neutral "Contributors:" list per module so the digest
+   * prose never has to attribute a specific action to a specific person.
+   *
+   * @param array $module
+   *   Module data array as returned by NewsletterDataFetcherService.
+   * @param string $since
+   *   ISO 8601 start datetime string (inclusive lower bound).
+   * @param string $until
+   *   ISO 8601 end datetime string (inclusive upper bound).
+   *
+   * @return string[]
+   *   Display strings ("Real Name (username)" where a name differs from the
+   *   username, otherwise the bare username), deduplicated and sorted.
+   */
+  public function buildContributors(array $module, string $since, string $until): array {
+    $sinceTs = strtotime($since) ?: 0;
+    $untilTs = strtotime($until) ?: PHP_INT_MAX;
+
+    // Keyed by a stable identity (username, or name when no username exists)
+    // so each person is counted once regardless of how they participated.
+    // $nameToKey maps a real name back to its key so a username-less commit
+    // author does not create a duplicate of someone already keyed by username.
+    // $commits tracks per-person in-window commit count, shown as "[N]".
+    $people = [];
+    $nameToKey = [];
+    $commits = [];
+    // Records a participant and returns their stable key (or NULL if empty).
+    $add = function (string $user, string $name) use (&$people, &$nameToKey, &$commits): ?string {
+      $user = trim($user);
+      $name = trim($name);
+      if ($user === '' && $name === '') {
+        return NULL;
+      }
+      // A name-only contributor (e.g. a commit author) folds into an existing
+      // person if that name is already known under a username-based key.
+      $key = $user !== '' ? $user : ($nameToKey[$name] ?? $name);
+      // If this person was first seen name-only (keyed by their name) and now
+      // arrives with a username, retire the name-only entry in favour of the
+      // username key so the two never coexist. Carry any commit tally across.
+      if ($user !== '' && $name !== '' && isset($people[$name]) && !isset($nameToKey[$name])) {
+        if (!empty($commits[$name])) {
+          $commits[$key] = ($commits[$key] ?? 0) + $commits[$name];
+          unset($commits[$name]);
+        }
+        unset($people[$name]);
+      }
+      // Prefer the "Real Name (username)" form; fall back to whichever we have.
+      $display = ($name !== '' && $user !== '' && $name !== $user)
+        ? "$name ($user)"
+        : ($user !== '' ? $user : $name);
+      // First non-empty display wins, but upgrade a bare username to the
+      // richer "Name (username)" form if we later learn the real name.
+      if (!isset($people[$key]) || (str_contains($display, '(') && !str_contains($people[$key], '('))) {
+        $people[$key] = $display;
+      }
+      if ($name !== '') {
+        $nameToKey[$name] = $key;
+      }
+      return $key;
+    };
+
+    $inWindow = function (?string $ts) use ($sinceTs, $untilTs): bool {
+      if (!$ts) {
+        return FALSE;
+      }
+      $t = strtotime($ts);
+      return $t !== FALSE && $t >= $sinceTs && $t <= $untilTs;
+    };
+
+    foreach ($module['issues'] ?? [] as $issue) {
+      if (!empty($issue['confidential'])) {
+        continue;
+      }
+      foreach ($issue['comments'] ?? [] as $comment) {
+        if ($inWindow($comment['created_at'] ?? NULL)) {
+          $add($comment['author'] ?? '', $comment['author_name'] ?? '');
+        }
+      }
+    }
+
+    foreach ($module['merge_requests'] ?? [] as $mr) {
+      // An MR counts if it was opened, touched, or merged within the window.
+      if ($inWindow($mr['created_at'] ?? NULL)
+        || $inWindow($mr['updated_at'] ?? NULL)
+        || $inWindow($mr['merged_at'] ?? NULL)) {
+        $add($mr['author'] ?? '', $mr['author_name'] ?? '');
+      }
+    }
+
+    foreach ($module['commits'] ?? [] as $commit) {
+      // Commits carry an author name but no GitLab username.
+      if ($inWindow($commit['authored_date'] ?? NULL)) {
+        $key = $add('', $commit['author_name'] ?? '');
+        if ($key !== NULL) {
+          $commits[$key] = ($commits[$key] ?? 0) + 1;
+        }
+      }
+    }
+
+    // Append the in-window commit count as "[N]" where N > 0.
+    $list = [];
+    foreach ($people as $key => $display) {
+      $count = $commits[$key] ?? 0;
+      $list[] = $count > 0 ? "$display [$count]" : $display;
+    }
+    sort($list, SORT_NATURAL | SORT_FLAG_CASE);
+    return $list;
+  }
+
+  /**
+   * Extracts the searchable name tokens from a contributor display string.
+   *
+   * "Real Name (username)" yields both "Real Name" and "username"; a bare
+   * value yields just itself. A trailing commit-count suffix ("[3]") is
+   * ignored. Tokens shorter than 3 characters are dropped to avoid matching
+   * common words.
+   *
+   * @param string[] $contributors
+   *   Display strings from buildContributors().
+   *
+   * @return string[]
+   *   Distinct lower-cased tokens to scan the prose for.
+   */
+  private function contributorNameTokens(array $contributors): array {
+    $tokens = [];
+    foreach ($contributors as $display) {
+      // Strip the trailing "[N]" commit-count suffix before parsing.
+      $display = preg_replace('/\s*\[\d+\]\s*$/', '', $display);
+      if (preg_match('/^(.*?)\s*\(([^)]+)\)\s*$/', $display, $m)) {
+        $tokens[] = trim($m[1]);
+        $tokens[] = trim($m[2]);
+      }
+      else {
+        $tokens[] = trim($display);
+      }
+    }
+    $tokens = array_filter(array_unique($tokens), fn($t) => mb_strlen($t) >= 3);
+    return array_values($tokens);
+  }
+
+  /**
+   * Finds contributor names that appear in the prose outside the "Contributors:" line.
+   *
+   * @param string $html
+   *   The generated section.
+   * @param string[] $contributors
+   *   Display strings from buildContributors().
+   *
+   * @return string[]
+   *   The name tokens that leaked into the prose body.
+   */
+  public function findNameLeaks(string $html, array $contributors): array {
+    $tokens = $this->contributorNameTokens($contributors);
+    if (!$tokens) {
+      return [];
+    }
+
+    // Strip the legitimate "Contributors:" line(s) before scanning so the list
+    // itself never counts as a leak. Matches from the label to end of line.
+    $body = preg_replace('/Contributors:.*$/mi', '', $html);
+
+    $leaks = [];
+    foreach ($tokens as $token) {
+      // Word-boundary, case-insensitive. Usernames can contain non-word chars
+      // (dots, hyphens), so anchor on surrounding whitespace/punctuation.
+      $pattern = '/(?<![\w@.\-])' . preg_quote($token, '/') . '(?![\w@.\-])/i';
+      if (preg_match($pattern, $body)) {
+        $leaks[] = $token;
+      }
+    }
+    return $leaks;
+  }
+
+  /**
+   * Backstop that removes per-person action attribution from a module section.
+   *
+   * The generation prompt instructs the LLM to keep names out of the prose and
+   * confine them to a trailing "Contributors:" line. This catches the cases
+   * where it slips: it scans only for the known active contributors (no
+   * heuristic name detection, so no false positives), and if any leak into the
+   * prose it asks the LLM to rewrite the offending sentences in passive voice.
+   * Fails open — if the rewrite errors or still leaks, the original is logged
+   * and shipped rather than blocking the digest.
+   *
+   * @param string $html
+   *   The generated section.
+   * @param string[] $contributors
+   *   Display strings from buildContributors().
+   * @param string $machineName
+   *   Module machine name, for log context.
+   *
+   * @return string
+   *   The section with name attribution removed where possible.
+   */
+  public function stripNameAttribution(string $html, array $contributors, string $machineName = ''): string {
+    $leaks = $this->findNameLeaks($html, $contributors);
+    if (!$leaks) {
+      return $html;
+    }
+
+    $this->logger->warning('Digest name-attribution leak in module @module: @names', [
+      '@module' => $machineName,
+      '@names' => implode(', ', $leaks),
+    ]);
+
+    $leakList = implode(', ', $leaks);
+    $contributorsList = implode(', ', $contributors);
+    $prompt = <<<PROMPT
+You are correcting a project digest section. The prose wrongly attributes work to specific people. Rewrite only the sentences that name any of these people so they describe the work in the passive voice without naming anyone: $leakList
+
+Rules:
+- Do not name any of those people anywhere except a trailing "Contributors:" line.
+- Keep the trailing "Contributors: $contributorsList" line exactly as-is (add it if missing).
+- Leave every other sentence, HTML tag, link, and citation exactly as-is.
+- Output the full corrected fragment and nothing else.
+
+--- SECTION ---
+$html
+PROMPT;
+
+    $this->promptLog[] = ['label' => "stripNameAttribution:{$machineName}", 'prompt' => $prompt];
+
+    $candidate = $html;
+    try {
+      $rewritten = $this->summariser->complete($prompt, ['newsletter_name_strip']);
+      if (trim($rewritten) !== '') {
+        $candidate = $rewritten;
+      }
+    }
+    catch (\Throwable $e) {
+      $this->logger->warning('Digest name-strip rewrite failed for @module: @msg', [
+        '@module' => $machineName,
+        '@msg' => $e->getMessage(),
+      ]);
+    }
+
+    // Re-scan once. If the rewrite still leaks, log and ship (fail-open).
+    $remaining = $this->findNameLeaks($candidate, $contributors);
+    if ($remaining) {
+      $this->logger->warning('Digest name-attribution still present after rewrite in @module: @names', [
+        '@module' => $machineName,
+        '@names' => implode(', ', $remaining),
+      ]);
+    }
+
+    return $candidate;
+  }
+
+  /**
    * Calls the LLM to produce a summary section for a single module.
    *
    * @param array $module
@@ -638,7 +895,7 @@ class DailyDigestService {
         "After the project summary prose, add a single subsection titled \"$howToHelpHeading\" aimed at a non-technical executive. Suggest 2-3 concrete, high-level ways a leader could support or unblock progress (e.g. resourcing, stakeholder alignment, decision-making, funding, advocacy). Keep it under 60 words. Do not add any other 'How can I help' text anywhere else in the section.\nCRITICAL: Before writing each suggestion, verify it against the issue data. Do not suggest actions that are already in progress or covered by an existing MR — for example, do not suggest that work needs to be started if an issue already has a Related MR.",
       ],
       default => [
-        "You are writing for a technical developer audience.\nFocus on: what was merged or shipped, specific bugs fixed, APIs changed, contributors, and what is blocking progress.\nBe specific — mention function names, module names, and MR references where relevant.",
+        "You are writing for a technical developer audience.\nFocus on: what was merged or shipped, specific bugs fixed, APIs changed, and what is blocking progress.\nBe specific — mention function names, module names, and MR references where relevant.",
         "After the project summary prose, add a single subsection titled \"$howToHelpHeading\" aimed at a developer. Suggest 2-3 concrete technical actions a contributor could take right now. Keep it under 60 words. Do not add any other 'How can I help' text anywhere else in the section.\nCRITICAL: Before writing each suggestion, check the data for each issue:\n- If an issue shows a Related MR with state 'opened', do NOT suggest creating a patch or MR — one already exists. Suggest reviewing it instead.\n- If all Related MRs for an issue are merged, do NOT suggest reviewing them — they are already done.\n- If an issue is unassigned with no Related MRs, it is a good candidate to pick up.\n- Only suggest actions that are genuinely still needed given the current state in the data above.",
       ],
     };
@@ -646,6 +903,15 @@ class DailyDigestService {
     $confidentialNote = $confidentialCount > 0
       ? "Note: $confidentialCount confidential issue(s) existed in this period but have been excluded from the data below. Mention briefly at the end of your section that $confidentialCount confidential issue(s) were not included in this analysis."
       : '';
+
+    // People who were actually active in the window. The prose must not
+    // attribute actions to anyone; these names appear only in the trailing
+    // "Contributors:" line.
+    $contributors = $this->buildContributors($module, $since, $until);
+    $contributorsList = $contributors ? implode(', ', $contributors) : '(none active this period)';
+    $contributorsInstruction = $contributors
+      ? "End your section with a single line listing the people who were active this period, exactly in this form (plain text, no <strong>): \"Contributors: $contributorsList\". Use only the names from that list, verbatim, keeping any trailing \"[N]\" commit count exactly as shown. Do not introduce any other names."
+      : "Do not name any individual people in this section. No one was active enough this period to list.";
 
     $prompt = <<<PROMPT
 You are a technical writer producing a newsletter section about recent Drupal module activity.
@@ -659,7 +925,8 @@ Focus your report on activity that occurred within the reporting period (comment
 Do not list every issue/MR individually — synthesise into prose. Keep it under 200 words.
 Do not use emoticons or mdashes. Do not wrap usernames or contributor names in <strong> tags — mention them as plain text.
 When mentioning a specific issue or MR, always hyperlink it using the URL provided in the data (e.g. <a href="URL">Issue Title</a> or the Markdown equivalent). Do not reference issues or MRs by number alone — always use their title as the link text.
-When mentioning contributors, use the format "Real Name (username)" when a real name is available in the data, otherwise use just the username.
+Do NOT attribute any action to a named individual. Do not say who merged, fixed, reviewed, authored, or opened anything. The "Author" and "Assigned" labels in the data are context only — never surface them as "X did Y". Describe the work itself in the passive voice (e.g. "the provider refactor was merged"), not the person who did it. The author of a merge request is often not the person who completed or merged the work, so naming them is misleading.
+$contributorsInstruction
 $confidentialNote
 $formatInstruction
 
@@ -679,6 +946,9 @@ PROMPT;
 
     $this->promptLog[] = ['label' => "summariseModule:{$machineName}:{$persona}", 'prompt' => $prompt];
     $output = $this->summariser->complete($prompt, ['newsletter_summarise']);
+    // Backstop: if a contributor name slipped into the prose despite the
+    // instruction, rewrite the offending sentences before linkifying.
+    $output = $this->stripNameAttribution($output, $contributors, $machineName);
     return $this->linkifyHtml($output, $module);
   }
 

--- a/web/modules/custom/issue_analysis/tests/src/Unit/Service/DigestContributorsTest.php
+++ b/web/modules/custom/issue_analysis/tests/src/Unit/Service/DigestContributorsTest.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Drupal\Tests\issue_analysis\Unit\Service;
+
+use Drupal\issue_analysis\Service\AiSummariserService;
+use Drupal\issue_analysis\Service\DailyDigestService;
+use Drupal\issue_analysis\Service\NewsletterDataFetcherService;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Logger\LoggerChannelFactoryInterface;
+use Drupal\Core\Logger\LoggerChannelInterface;
+use Drupal\Core\State\StateInterface;
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\Group;
+use Prophecy\PhpUnit\ProphecyTrait;
+
+/**
+ * Unit tests for name-free attribution in DailyDigestService.
+ *
+ * Covers buildContributors() (who is "active in the period") and the
+ * name-leak backstop (findNameLeaks / stripNameAttribution).
+ */
+#[Group('issue_analysis')]
+class DigestContributorsTest extends TestCase {
+
+  use ProphecyTrait;
+
+  private const SINCE = '2026-06-24T00:00:00Z';
+  private const UNTIL = '2026-06-25T00:00:00Z';
+
+  /**
+   * Builds a DailyDigestService with mocked dependencies.
+   */
+  private function makeService(?AiSummariserService $summariser = NULL): DailyDigestService {
+    $fetcher = $this->prophesize(NewsletterDataFetcherService::class)->reveal();
+    $summariser = $summariser ?? $this->prophesize(AiSummariserService::class)->reveal();
+    $state = $this->prophesize(StateInterface::class)->reveal();
+    $etm = $this->prophesize(EntityTypeManagerInterface::class)->reveal();
+    $channel = $this->prophesize(LoggerChannelInterface::class)->reveal();
+    $loggerFactory = $this->prophesize(LoggerChannelFactoryInterface::class);
+    $loggerFactory->get(\Prophecy\Argument::any())->willReturn($channel);
+    return new DailyDigestService($fetcher, $summariser, $state, $etm, $loggerFactory->reveal());
+  }
+
+  /**
+   * Makes a summariser mock whose complete() returns the given string.
+   */
+  private function summariserReturning(string $response): AiSummariserService {
+    $s = $this->prophesize(AiSummariserService::class);
+    $s->complete(\Prophecy\Argument::cetera())->willReturn($response);
+    return $s->reveal();
+  }
+
+  // ---------------------------------------------------------------------------
+  // buildContributors()
+  // ---------------------------------------------------------------------------
+
+  public function testInWindowCommentAuthorIsIncluded(): void {
+    $module = [
+      'issues' => [
+        [
+          'comments' => [
+            ['author' => 'alice', 'author_name' => 'Alice Smith', 'created_at' => '2026-06-24T10:00:00Z'],
+          ],
+        ],
+      ],
+    ];
+    $result = $this->makeService()->buildContributors($module, self::SINCE, self::UNTIL);
+    $this->assertSame(['Alice Smith (alice)'], $result);
+  }
+
+  public function testCommentOutsideWindowIsExcluded(): void {
+    $module = [
+      'issues' => [
+        [
+          'comments' => [
+            ['author' => 'bob', 'author_name' => 'Bob Jones', 'created_at' => '2026-06-01T10:00:00Z'],
+          ],
+        ],
+      ],
+    ];
+    $this->assertSame([], $this->makeService()->buildContributors($module, self::SINCE, self::UNTIL));
+  }
+
+  public function testStaleAssigneeWithNoActivityIsExcluded(): void {
+    // The issue has an assignee but no in-window activity by them.
+    $module = [
+      'issues' => [
+        [
+          'author' => 'carol',
+          'author_name' => 'Carol',
+          'assignees' => ['dave'],
+          'assignee_names' => ['Dave'],
+          'comments' => [],
+        ],
+      ],
+    ];
+    $this->assertSame([], $this->makeService()->buildContributors($module, self::SINCE, self::UNTIL));
+  }
+
+  public function testMergedMrAuthorInWindowIsIncluded(): void {
+    $module = [
+      'merge_requests' => [
+        ['author' => 'eve', 'author_name' => 'Eve', 'merged_at' => '2026-06-24T12:00:00Z', 'created_at' => '2026-05-01T00:00:00Z'],
+      ],
+    ];
+    $this->assertSame(['Eve (eve)'], $this->makeService()->buildContributors($module, self::SINCE, self::UNTIL));
+  }
+
+  public function testCommitAuthorInWindowIsIncludedByNameWithCount(): void {
+    $module = [
+      'commits' => [
+        ['author_name' => 'Frank', 'authored_date' => '2026-06-24T09:00:00Z'],
+      ],
+    ];
+    $this->assertSame(['Frank [1]'], $this->makeService()->buildContributors($module, self::SINCE, self::UNTIL));
+  }
+
+  public function testCommitCountAccumulatesPerPerson(): void {
+    $module = [
+      'commits' => [
+        ['author_name' => 'Grace', 'authored_date' => '2026-06-24T09:00:00Z'],
+        ['author_name' => 'Grace', 'authored_date' => '2026-06-24T10:00:00Z'],
+        ['author_name' => 'Grace', 'authored_date' => '2026-06-24T11:00:00Z'],
+      ],
+    ];
+    $this->assertSame(['Grace [3]'], $this->makeService()->buildContributors($module, self::SINCE, self::UNTIL));
+  }
+
+  public function testContributorWithNoCommitsHasNoBracket(): void {
+    // Active via a comment only — no commit, so no "[N]" suffix.
+    $module = [
+      'issues' => [
+        ['comments' => [['author' => 'heidi', 'author_name' => 'Heidi', 'created_at' => '2026-06-24T10:00:00Z']]],
+      ],
+    ];
+    $this->assertSame(['Heidi (heidi)'], $this->makeService()->buildContributors($module, self::SINCE, self::UNTIL));
+  }
+
+  public function testCommitCountFollowsUsernameFoldRegardlessOfOrder(): void {
+    // Commit (name only) before the MR that supplies the username: the count
+    // must attach to the merged "Name (username)" entry.
+    $module = [
+      'commits' => [
+        ['author_name' => 'Ivan', 'authored_date' => '2026-06-24T10:00:00Z'],
+        ['author_name' => 'Ivan', 'authored_date' => '2026-06-24T11:00:00Z'],
+      ],
+      'merge_requests' => [
+        ['author' => 'ivan', 'author_name' => 'Ivan', 'merged_at' => '2026-06-24T12:00:00Z'],
+      ],
+    ];
+    $this->assertSame(['Ivan (ivan) [2]'], $this->makeService()->buildContributors($module, self::SINCE, self::UNTIL));
+  }
+
+  public function testPersonCountedOnceAcrossSources(): void {
+    $module = [
+      'issues' => [
+        ['comments' => [['author' => 'alice', 'author_name' => 'Alice Smith', 'created_at' => '2026-06-24T10:00:00Z']]],
+      ],
+      'merge_requests' => [
+        ['author' => 'alice', 'author_name' => 'Alice Smith', 'merged_at' => '2026-06-24T11:00:00Z'],
+      ],
+    ];
+    $this->assertSame(['Alice Smith (alice)'], $this->makeService()->buildContributors($module, self::SINCE, self::UNTIL));
+  }
+
+  public function testConfidentialIssueCommentsAreSkipped(): void {
+    $module = [
+      'issues' => [
+        [
+          'confidential' => TRUE,
+          'comments' => [['author' => 'secret', 'author_name' => 'Secret', 'created_at' => '2026-06-24T10:00:00Z']],
+        ],
+      ],
+    ];
+    $this->assertSame([], $this->makeService()->buildContributors($module, self::SINCE, self::UNTIL));
+  }
+
+  public function testResultIsSortedAndDeduplicated(): void {
+    $module = [
+      'issues' => [
+        ['comments' => [['author' => 'zoe', 'author_name' => 'Zoe', 'created_at' => '2026-06-24T10:00:00Z']]],
+      ],
+      'merge_requests' => [
+        ['author' => 'amy', 'author_name' => 'Amy', 'merged_at' => '2026-06-24T11:00:00Z'],
+      ],
+      'commits' => [
+        ['author_name' => 'Amy', 'authored_date' => '2026-06-24T10:00:00Z'],
+      ],
+    ];
+    $result = $this->makeService()->buildContributors($module, self::SINCE, self::UNTIL);
+    // Amy (amy) sorts before Zoe; commit "Amy" must not double-count, and her
+    // single commit shows as "[1]". Zoe has no commit, so no bracket.
+    $this->assertSame(['Amy (amy) [1]', 'Zoe (zoe)'], $result);
+  }
+
+  public function testNameOnlyCommitFoldsIntoUsernameRegardlessOfOrder(): void {
+    // Commit (name only) appears in data BEFORE the MR that carries the
+    // username — the two must still collapse to one entry.
+    $module = [
+      'commits' => [
+        ['author_name' => 'Amy', 'authored_date' => '2026-06-24T10:00:00Z'],
+      ],
+      'merge_requests' => [
+        ['author' => 'amy', 'author_name' => 'Amy', 'merged_at' => '2026-06-24T11:00:00Z'],
+      ],
+    ];
+    $this->assertSame(['Amy (amy) [1]'], $this->makeService()->buildContributors($module, self::SINCE, self::UNTIL));
+  }
+
+  // ---------------------------------------------------------------------------
+  // findNameLeaks()
+  // ---------------------------------------------------------------------------
+
+  public function testNameInProseIsFlagged(): void {
+    $html = '<p>Alice Smith merged the fix.</p><p>Contributors: Alice Smith (alice)</p>';
+    $leaks = $this->makeService()->findNameLeaks($html, ['Alice Smith (alice)']);
+    $this->assertContains('Alice Smith', $leaks);
+  }
+
+  public function testUsernameInProseIsFlagged(): void {
+    $html = '<p>The fix from alice was merged.</p><p>Contributors: Alice Smith (alice)</p>';
+    $leaks = $this->makeService()->findNameLeaks($html, ['Alice Smith (alice)']);
+    $this->assertContains('alice', $leaks);
+  }
+
+  public function testNameOnlyInContributorsLineIsNotFlagged(): void {
+    $html = '<p>The provider refactor was merged.</p><p>Contributors: Alice Smith (alice), Bob (bob)</p>';
+    $leaks = $this->makeService()->findNameLeaks($html, ['Alice Smith (alice)', 'Bob (bob)']);
+    $this->assertSame([], $leaks);
+  }
+
+  public function testLeakDetectionIgnoresCommitCountSuffix(): void {
+    // The contributor carries a "[2]" suffix; the name must still be detected
+    // when it leaks into the prose, and the suffix must not be treated as part
+    // of the name token.
+    $html = '<p>Alice Smith pushed the fix.</p><p>Contributors: Alice Smith (alice) [2]</p>';
+    $leaks = $this->makeService()->findNameLeaks($html, ['Alice Smith (alice) [2]']);
+    $this->assertContains('Alice Smith', $leaks);
+  }
+
+  public function testContributorsLineWithCountIsNotFlagged(): void {
+    $html = '<p>The provider refactor was merged.</p><p>Contributors: Alice Smith (alice) [3], Bob (bob)</p>';
+    $leaks = $this->makeService()->findNameLeaks($html, ['Alice Smith (alice) [3]', 'Bob (bob)']);
+    $this->assertSame([], $leaks);
+  }
+
+  public function testNoContributorsMeansNoLeaks(): void {
+    $html = '<p>Alice Smith merged the fix.</p>';
+    $this->assertSame([], $this->makeService()->findNameLeaks($html, []));
+  }
+
+  // ---------------------------------------------------------------------------
+  // stripNameAttribution()
+  // ---------------------------------------------------------------------------
+
+  public function testCleanProseIsReturnedUnchangedWithoutLlmCall(): void {
+    $s = $this->prophesize(AiSummariserService::class);
+    $s->complete(\Prophecy\Argument::cetera())->shouldNotBeCalled();
+    $service = $this->makeService($s->reveal());
+
+    $html = '<p>The refactor was merged.</p><p>Contributors: Alice Smith (alice)</p>';
+    $this->assertSame($html, $service->stripNameAttribution($html, ['Alice Smith (alice)'], 'ai'));
+  }
+
+  public function testLeakTriggersRewrite(): void {
+    $rewritten = '<p>The fix was merged.</p><p>Contributors: Alice Smith (alice)</p>';
+    $service = $this->makeService($this->summariserReturning($rewritten));
+
+    $leaked = '<p>Alice Smith merged the fix.</p><p>Contributors: Alice Smith (alice)</p>';
+    $result = $service->stripNameAttribution($leaked, ['Alice Smith (alice)'], 'ai');
+    $this->assertSame($rewritten, $result);
+  }
+
+  public function testRewriteFailureFailsOpenToOriginal(): void {
+    $s = $this->prophesize(AiSummariserService::class);
+    $s->complete(\Prophecy\Argument::cetera())->willThrow(new \RuntimeException('boom'));
+    $service = $this->makeService($s->reveal());
+
+    $leaked = '<p>Alice Smith merged the fix.</p><p>Contributors: Alice Smith (alice)</p>';
+    $result = $service->stripNameAttribution($leaked, ['Alice Smith (alice)'], 'ai');
+    // Fail-open: original is returned rather than blocking the digest.
+    $this->assertSame($leaked, $result);
+  }
+
+}


### PR DESCRIPTION
The digest narrated 'X merged/fixed Y' from the MR/issue author label, but authorship is not who did the work and there is no merge-actor signal at all, so attributions were routinely wrong (e.g. crediting the MR opener with a merge only a maintainer performed).

Stop the prose from attributing any action to a named person. Names now appear only in a neutral per-topic 'Contributors:' line listing people who were actually active in the reporting window (commented, authored an in-window MR, committed, or had an MR merged), each followed by their in-window commit count as '[N]' (omitted when zero) for a neutral effort signal.

A deterministic backstop scans the output for known-contributor names leaking into the prose and asks the LLM to rewrite the offending sentences in passive voice, failing open if it cannot.

Input data to the LLM is unchanged; the status fact-checker is untouched and complementary. TL;DR and 2026-capabilities sections inherit name-free prose since they consume the module summaries.

Adds buildContributors(), findNameLeaks(), stripNameAttribution() and unit tests.